### PR TITLE
gameObjects.js CheckFreighter Hotfix

### DIFF
--- a/gameObjects.js
+++ b/gameObjects.js
@@ -69,13 +69,13 @@ var spaceship = {
       //this.supplies += 2;
     //}
 
+    wormholeCheck();
+    
     if(checkFreighter(this.location[0], this.location[1]) === true){
       this.energy = 1000;
       this.supplies += this.supplies * 0.02;
     }
-
-    wormholeCheck();
-
+    
     setData();
 
     this.displayCurrentCP();


### PR DESCRIPTION
Having the if that calls checkFreighter before wormholeCheck() results in not being able to go out of bounds.

Moved call after the wormholeCheck() to allow bound wormholes to work.