### PR TITLE
US-2.10 Add Bad Max event

### DIFF
--- a/checkEvents.js
+++ b/checkEvents.js
@@ -67,6 +67,29 @@ function checkEvents(x, y){
     window.location.reload();
     return 3;
   }
+  
+  //Bad Max is hard coded to [7][7] for now
+  if(gameSpace[x][y].celestialObjects.includes("Bad Max")){
+    randomNum = Math.floor(Math.random() * 100);
+    console.log("randomNum is " + randomNum);
+    
+    //We fight off Bad Max and live
+    if (randomNum < 33){
+      alert("You've encountered Bad Max... Fortunately, your crew was able to heroically fight them off successfully!");
+    }
+    //Bad Max boards the ship and steals all credits and half of supplies
+    else if (randomNum > 66){
+      alert("Bad Max has boarded your ship! His crew of goons stole all your credits and half of your supplies!");
+      spaceship.credits = 0;
+      spaceship.supplies = Math.floor(spaceship.supplies / 2); 
+    }
+    //Bad Max blows up your ship, everyone dies, game over
+    else{
+      alert("BAD MAX HAS ATTACKED AND DESTROYED YOUR SHIP! EVERYONE HAS DIED. GAME OVER.");
+      window.location.reload();
+    }
+    return 0;
+  }
 
   else {
     return 0;

--- a/gameObjects.js
+++ b/gameObjects.js
@@ -220,6 +220,9 @@ window.onload = function() {
   gameSpace[6][5].celestialObjects.push("asteroid");
   gameSpace[0][1].celestialObjects.push("asteroid");
   gameSpace[3][2].celestialObjects.push("asteroid");
+  
+  //Bad Max hard coded temporarily
+  gameSpace[7][7].celestialObjects.push("Bad Max");
 
   // Display starting CM with the 3 planets on it
   celestialMap.display();


### PR DESCRIPTION
Closes #33  

Implemented the requirements for Bad Max encounter. Simple addition that builds on general checkEvents function. If player lands on Bad Max, random number is generated and there's an equal chances for one of three encounters:

1. Fight them off.
2. Die. Game over.
3. Be boarded. Lose half of supplies and all credits.

Let me know if you see the need for any changes.