### PR TITLE
US 2.2 DevMenu Hotfix

### DIFF
--- a/checkEvents.js
+++ b/checkEvents.js
@@ -3,13 +3,13 @@
 
 function checkEvents(x, y){
 
-  if(gameSpace[x][y].celestialObjects.includes("freighter")){
+  if(gameSpace[x][y].celestialObjects.includes("Freighter")){
     alert("Freighter found! Energy 1000 & Supplies increased by 2%");
     return 1;
   }
 
   if(gameSpace[x][y].celestialObjects.includes("Meteor Storm")){
-    alert("Meteor Storm. Ship damaged!");
+    alert("Meteor Storm. Ship damaged! Energy will now deplete at 5 time the usual.");
     spaceship.damaged = true;
     return 2;
   }

--- a/devDataSave.js
+++ b/devDataSave.js
@@ -1,52 +1,238 @@
 function setStateData()
 {
+    var RandWrm;
+    var FixWrmLocation = ['0.5', '0.5'];
+    var PlayStyleMor;
+    var RecipeLoc = ['0.5', '0.5'];
+
+    //textbox value pulls
     var MapSize = document.getElementById("Dimensions").value;
     var StartLocation = document.getElementById("Location").value;
     MapSize = MapSize.split(',');
     StartLocation = StartLocation.split(',');
-    //window.alert(MapSize.join("\n"));
-    //window.alert(StartLocation.join("\n"));
-
-    /*if(MapSize[0] < StartLocation[0] || MapSize[1] < StartLocation[1]) {
-      window.alert("Please fix the Current Location values inputted so they are within the Game Size bounds set.")
-      return;
-    }
-    */
+    
     var Eng = document.getElementById("Energy").value;
     var Supl = document.getElementById("Supplies").value;
     var Cred = document.getElementById("Credits").value;
-                    
-    var RandWrm;
-    var FixWrmLocation;
+                  
+    //radio button checks
     if(document.getElementById("Random").checked){
-      RandWrm = 1;
-      FixWrmLocation = [0, 0];
-
+      RandWrm = '1';
     } else if (document.getElementById("Fixed").checked) {
-      RandWrm =0;
+      RandWrm = '0';
       FixWrmLocation = document.getElementById("FixedWormhole").value;
       FixWrmLocation = FixWrmLocation.split(',');
-      
-      /*if(MapSize[0] < FixWrmLocation[0] || MapSize[1] < FixWrmLocation[1]){
-        window.alert("Please change the Fixed Wormhole location values inputted so they are within the Game Size bounds set.")
-        return;
-      }
-      */
     }
-
-    var PlayStyleMor;
+    
     if(document.getElementById("Mortal").checked){
-      PlayStyleMor = 1;
-
+      PlayStyleMor = '1';
     } else if (document.getElementById("Immortal").checked) {
-      PlayStyleMor = 0;
+      PlayStyleMor = '0';
+    }
+
+    if(document.getElementById("RandomRecipe").checked){
+      RecipeLoc[0] = Math.floor((Math.random() * MapSize[0] + 1));
+      RecipeLoc[1] = Math.floor((Math.random() * MapSize[1] + 1));
+
+    } else if (document.getElementById("FixedRecipe").checked) {
+      RecipeLoc = document.getElementById("RecipeLocation").value;
+      RecipeLoc = RecipeLoc.split(',');
+    }
+ 
+    //bounds checking
+    if(Number(MapSize[0]) < 9 || Number(MapSize[0]) > 255 || Number(MapSize[1]) < 9 || Number(MapSize[1]) > 255){
+      window.alert("Map dimensions is limited to a range of at least 9 to 255 so that all items may be placed. Setting Map size to default 128,128.");
+      MapSize[0] = '128'; 
+      MapSize[1] = '128';
+    }
+    if(Number(StartLocation[0]) > Number(MapSize[0]) || Number(StartLocation[1]) > Number(MapSize[1]) || Number(StartLocation[0]) < 0 || Number(StartLocation[1]) < 0) {
+      window.alert("Current location must be within the range of the map. Setting current location to a point within range.");
+      StartLocation[0] = Math.floor((Math.random() * MapSize[0] + 1)); 
+      StartLocation[1] = Math.floor((Math.random() * MapSize[1] + 1));
+    }
+    if(Number(MapSize[0]) < Number(FixWrmLocation[0]) || Number(MapSize[1]) < Number(FixWrmLocation[1]) || Number(FixWrmLocation[0]) < 0 || Number(FixWrmLocation[1]) < 0) {
+      window.alert("Fixed wormhold location must be within the range of the map. Setting Fixed wormhole location to Current Location values");
+      FixWrmLocation[0] = StartLocation[0]; 
+      FixWrmLocation[1] = StartLocation[1];
+    }
+    if(Number(MapSize[0]) < Number(RecipeLoc[0]) || Number(MapSize[1]) < Number(RecipeLoc[1]) || Number(RecipeLoc[0]) < 0 || Number(RecipeLoc[1]) < 0) {
+      window.alert("Fixed recipe location must be within the range of the map. Setting Fixed recipe location to the default location 25,25");
+      RecipeLoc[0] = '25'; 
+      RecipeLoc[1] = '25';
+    }
+
+    //localStorage string set up
+    var parser = "#";
+
+    var StateConfig = MapSize[0].concat(parser, MapSize[1], parser, StartLocation[0], parser, StartLocation[1], parser, Eng, parser, Supl, parser, Cred, parser, RandWrm, parser, FixWrmLocation[0], parser, FixWrmLocation[1], parser, PlayStyleMor, parser, RecipeLoc[0], parser, RecipeLoc[1]);
+    
+    setMapData(StateConfig, MapSize, parser);
+}
+
+
+
+function setMapData(StateConfig, MapSize, parser) {
+
+    var i;
+    var PlanetCeleron = ['0.5', '0.5']; PlanetXeon = ['0.5', '0.5']; PlanetRyzen = ['0.5', '0.5'];
+    var Planets = [ PlanetCeleron[0], PlanetCeleron[1], PlanetXeon[0], PlanetXeon[1], PlanetRyzen[0], PlanetRyzen[1] ];
+
+    var NumberofStations = document.getElementById("StationNum").value;
+    var SpaceStations = ['0.5', '0.5', '0.5', '0.5', '0.5', '0.5'];
+
+    var NumberofFreighters = document.getElementById("FreighterNum").value;
+    var AbandonedFreighter = ['0.5', '0.5', '0.5', '0.5', '0.5', '0.5'];
+
+    var NumberofMeteors = document.getElementById("MeteorNum").value;
+    var MeteorStorms = ['0.5', '0.5', '0.5', '0.5', '0.5', '0.5'];
+
+    var NumberofAsteroids = document.getElementById("AsteroidsNum").value;
+    var Asteroids = ['0.5', '0.5', '0.5', '0.5', '0.5', '0.5'];
+
+
+    if(document.getElementById("RandomPlanet").checked){
+      for(i = 0; i < Planets.length; i+=2) {
+        Planets[i] = Math.floor((Math.random() * MapSize[0] + 1));
+        Planets[i+1] = Math.floor((Math.random() * MapSize[1] + 1));
+      }
+
+    } else if (document.getElementById("FixedPlanet").checked) {
+      PlanetCeleron = document.getElementById("planetCeleron").value;
+      PlanetXeon = document.getElementById("planetXeon").value;
+      PlanetRyzen = document.getElementById("planetRyzen").value;
+      PlanetCeleron = PlanetCeleron.split(',');
+      PlanetXeon = PlanetXeon.split(',');
+      PlanetRyzen = PlanetRyzen.split(',');
+      
+      Planets = [ PlanetCeleron[0], PlanetCeleron[1], PlanetXeon[0], PlanetXeon[1], PlanetRyzen[0], PlanetRyzen[1] ];
     }
     
-    var parser = "#";
-  
-    var StateConfig = MapSize[0].concat(parser, MapSize[1], parser, StartLocation[0], parser, StartLocation[1], parser, Eng, parser, Supl, parser, Cred, parser, RandWrm, parser, FixWrmLocation[0], parser, FixWrmLocation[1], parser, PlayStyleMor);
     
-    //alert(StateConfig);
+    //Space stations
+    if(NumberofStations != 0) {
+      if(document.getElementById("RandomStation").checked) {
+        for(i = 0; i < NumberofStations * 2; i+=2) {
+          SpaceStations[i] = Math.floor((Math.random() * MapSize[0] + 1));
+          SpaceStations[i+1] = Math.floor((Math.random() * MapSize[1] + 1));
+        }
+      } else if (document.getElementById("FixedStation").checked) {
+        SpaceStations = document.getElementById("SpaceStationLocations").value;
+        SpaceStations = SpaceStations.replace(/ /g, "");
+        SpaceStations = SpaceStations.replace(/#/g, ",");
+        SpaceStations = SpaceStations.split(',');
+        if(NumberofStations == 1) { SpaceStations[2] = '0.5'; SpaceStations[3] = '0.5'; SpaceStations[4] = '0.5'; SpaceStations[5] = '0.5';}
+        else if(NumberofStations == 2) { SpaceStations[4] = '0.5'; SpaceStations[5] = '0.5'; }
 
-    localStorage.setItem('Config', StateConfig);
+      }      
+    }
+   
+
+    //Abandoned Freighters 
+    if(NumberofFreighters != 0) {
+      if(document.getElementById("RandomFreighter").checked) {
+        for(i = 0; i < NumberofFreighters * 2; i+=2) {
+          AbandonedFreighter[i] = Math.floor((Math.random() * MapSize[0] + 1));
+          AbandonedFreighter[i+1] = Math.floor((Math.random() * MapSize[1] + 1));
+        }
+      } else if (document.getElementById("FixedFreighter").checked) {
+        AbandonedFreighter = document.getElementById("FreighterLocations").value;
+        AbandonedFreighter = AbandonedFreighter.replace(/ /g, "");
+        AbandonedFreighter = AbandonedFreighter.replace(/#/g, ",");
+        AbandonedFreighter = AbandonedFreighter.split(',');
+        if(NumberofFreighters == 1) { AbandonedFreighter[2] = '0.5'; AbandonedFreighter[3] = '0.5'; AbandonedFreighter[4] = '0.5'; AbandonedFreighter[5] = '0.5';}
+        else if(NumberofFreighters == 2) { AbandonedFreighter[4] = '0.5'; AbandonedFreighter[5] = '0.5'; }
+
+      }      
+    }
+    
+
+    //Meteor Storms
+    if(NumberofMeteors != 0) {
+      if(document.getElementById("RandomMeteor").checked) {
+        for(i = 0; i < NumberofMeteors * 2; i+=2) {
+          MeteorStorms[i] = Math.floor((Math.random() * MapSize[0] + 1));
+          MeteorStorms[i+1] = Math.floor((Math.random() * MapSize[1] + 1));
+        }
+      } else if (document.getElementById("FixedMeteor").checked) {
+        MeteorStorms = document.getElementById("MeteorLocations").value;
+        MeteorStorms = MeteorStorms.replace(/ /g, "");
+        MeteorStorms = MeteorStorms.replace(/#/g, ",");
+        MeteorStorms = MeteorStorms.split(',');
+        if(NumberofMeteors == 1) { MeteorStorms[2] = '0.5'; MeteorStorms[3] = '0.5'; MeteorStorms[4] = '0.5'; MeteorStorms[5] = '0.5';}
+        else if(NumberofMeteors == 2) { MeteorStorms[4] = '0.5'; MeteorStorms[5] = '0.5'; }
+
+      }      
+    }
+   
+
+    //Asteroids
+    if(NumberofAsteroids != 0) {
+      if(document.getElementById("RandomAsteroids").checked) {
+        for(i = 0; i < NumberofAsteroids * 2; i+=2) {
+          Asteroids[i] = Math.floor((Math.random() * MapSize[0] + 1));
+          Asteroids[i+1] = Math.floor((Math.random() * MapSize[1] + 1));
+        }
+      } else if (document.getElementById("FixedAsteroids").checked) {
+        Asteroids = document.getElementById("AsteroidsLocations").value;
+        Asteroids = Asteroids.replace(/ /g, "");
+        Asteroids = Asteroids.replace(/#/g, ",");
+        Asteroids = Asteroids.split(',');
+        if(NumberofAsteroids == 1) { Asteroids[2] = '0.5'; Asteroids[3] = '0.5'; Asteroids[4] = '0.5'; Asteroids[5] = '0.5';}
+        else if(NumberofAsteroids == 2) { Asteroids[4] = '0.5'; Asteroids[5] = '0.5'; }
+
+      }      
+    }
+    
+
+    //all 30 Map Items loaded (Planets, Space Stations, Abandoned Freighter, Meteor Storms, or Asteroids)
+    var MapItems = [Planets[0], Planets[1], Planets[2], Planets[3], Planets[4], Planets[5], SpaceStations[0], SpaceStations[1], SpaceStations[2], SpaceStations[3], SpaceStations[4], SpaceStations[5], AbandonedFreighter[0], AbandonedFreighter[1], AbandonedFreighter[2], AbandonedFreighter[3], AbandonedFreighter[4], AbandonedFreighter[5], MeteorStorms[0], MeteorStorms[1], MeteorStorms[2], MeteorStorms[3], MeteorStorms[4], MeteorStorms[5], Asteroids[0], Asteroids[1], Asteroids[2], Asteroids[3], Asteroids[4], Asteroids[5] ];
+    //window.alert(MapItems.join("\n"));
+
+    BoundsChecking(StateConfig, MapItems, MapSize, parser);
+}
+
+
+
+function BoundsChecking(StateConfig, MapItems, MapSize, parser) {
+
+  var i;
+  var ErrorFound = false;
+
+
+  for(i = 0; i < MapItems.length; i+=2) {
+
+      if(Number(MapItems[i]) > Number(MapSize[0]) || Number(MapItems[i]) < 0) {
+        MapItems[i] = Math.floor((Math.random() * MapSize[0] + 1));
+        ErrorFound = true;
+      }
+      
+      if(Number(MapItems[i+1]) > Number(MapSize[1]) || Number(MapItems[i+1]) < 0) {
+        MapItems[i+1] = Math.floor((Math.random() * MapSize[1] + 1));
+        ErrorFound = true;
+      }
+  }
+
+  if(ErrorFound == true) {
+    window.alert("An out of bounds error was found in your specified Map items (Planets, Space Stations, Abandoned Freighter, Meteor Storms, or Asteroids). The values have been corrected to be wintin the bounds of the Map.");
+  }
+  
+
+  //Planets added to overall string
+  StateConfig = StateConfig.concat(parser, MapItems[0], parser, MapItems[1], parser, MapItems[2], parser, MapItems[3], parser, MapItems[4], parser, MapItems[5]);
+  
+  //Space stations added
+  StateConfig = StateConfig.concat(parser, MapItems[6], parser, MapItems[7], parser, MapItems[8], parser, MapItems[9], parser, MapItems[10], parser, MapItems[11]);
+  
+  //Abandoned Freighters added
+  StateConfig = StateConfig.concat(parser, MapItems[12], parser, MapItems[13], parser, MapItems[14], parser, MapItems[15], parser, MapItems[16], parser, MapItems[17]);
+  
+  //Meteors Storms added
+  StateConfig = StateConfig.concat(parser, MapItems[18], parser, MapItems[19], parser, MapItems[20], parser, MapItems[21], parser, MapItems[22], parser, MapItems[23]);
+  
+  //Asteroids added
+  StateConfig = StateConfig.concat(parser, MapItems[24], parser, MapItems[25], parser, MapItems[26], parser, MapItems[27], parser, MapItems[28], parser, MapItems[29]);
+  
+
+  //window.alert(StateConfig);
+  localStorage.setItem('Config', StateConfig);
 }

--- a/devOptions.html
+++ b/devOptions.html
@@ -12,36 +12,136 @@
     <h1>
       <b>Developer Game Configuration Options</b>
     </h1>
-    <p>Please fill in all the fields for the state varibles, regular default values are intially set</p>
-    <hr>
+    <p>Please fill in all the fields default values are intially set</p><br><br>
+    
+    <!-- State Varibles -->
+    <label><b>State Varibles: </b></label><br>
+    <hr>    <!-- border line splitter -->
 
-    <label for="size"><b>Game Board Dimensions: </b></label>
-    <input type="text" name="Dim" id="Dimensions" value="128,128">
 
-    <label for=loc><b>Starting Location: </b></label>
-    <input type="text" name="loc" id="Location" value="100,100">
+    <!-- Map size -->
+    <label for="size"><b>Game Board Dimensions: </b></label><br>
+    <input type="text" name="Dim" id="Dimensions" style="width: 75%;" value="128,128"><br>
 
-    <label for="energy"><b>Energy: </b></label>
-    <input type="text" name="energy" id="Energy" value="1000">
+    <!-- Current location -->
+    <label for=loc><b>Starting Location: </b></label><br>
+    <input type="text" name="loc" id="Location" style="width: 75%;" value="100,100"><br>
 
-    <label "supplies"><b>Supplies: </b></label>
-    <input type="text" name="supplies" id="Supplies" value="100">
+    <!-- Energy -->
+    <label for="energy"><b>Energy: </b></label><br>
+    <input type="text" name="energy" id="Energy" style="width: 75%;" value="1000"><br>
 
-    <label for="credits"><b>Credits: </b></label>
-    <input type="text" name="credits" id="Credits" value="1000">
+    <!-- Supplies -->
+    <label "supplies"><b>Supplies: </b></label><br>
+    <input type="text" name="supplies" id="Supplies" style="width: 75%;" value="100"><br>
 
+    <!-- Credits -->
+    <label for="credits"><b>Credits: </b></label><br>
+    <input type="text" name="credits" id="Credits" style="width: 75%;" value="1000"><br>
+
+    <!-- Wormholes -->
     <label for="wormhole"><b>Wormhole behavior: </b></label><br>
       <input type="radio" name="worm" id="Random" checked> Random <br>
       <input type="radio" name="worm" id="Fixed"> Fixed <br><br>
 
-    <label for=fixedworm><b>Fixed Wormhole Location: </b></label>
-    <input type="text" name="wormF" id="FixedWormhole" value="20,20">
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <label for=fixedworm><b>Fixed Wormhole Location: </b></label><br>
+    <input type="text" name="wormF" id="FixedWormhole" style="margin-left: 1.5%; width: 35%;" value="50,50"><br>
 
-    <label for="play"><b>Play behavior: </b></label><br>
+    <label for="play"><b>Play Behavior: </b></label><br>
         <input type="radio" name="playtype" id="Mortal" checked> Mortal <br>
-        <input type="radio" name="playtype" id="Immortal"> Immortal <br></br>
+        <input type="radio" name="playtype" id="Immortal"> Immortal <br></br><br>
+
+    <!-- Winning Recipe Location -->
+    <label for=recipe><b>Winning Recipe Location: </b></label><br>
+    <input type="radio" name="recipe" id="RandomRecipe" checked> Random <br>
+    <input type="radio" name="recipe" id="FixedRecipe"> Fixed <br><br>
+
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <label for=recipe><b>Winning Recipe Fixed Location: </b></label><br>
+    <input type="text" name="recipe" id="RecipeLocation" style="margin-left: 1.5%; width: 35%;" value="25,25"><br>
+
+    <!-- Map Items -->
+    <label><b>Map Items: </b></label><br>
+    <hr>
+
+    <!-- PLANETS -->
+    <label for="planets"><b>Planet Locations: </b></label><br>
+        <input type="radio" name="planetType" id="RandomPlanet" checked> Random <br>
+        <input type="radio" name="planetType" id="FixedPlanet"> Fixed <br></br>
+    
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <label for=fixplanet><b>Planet Celeron Location: </b></label><br>
+    <input type="text" name="planetCeleron" id="planetCeleron" style="margin-left: 1.5%; width: 35%;" value="2,0"><br>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <label for=fixplanet><b>Planet Xeon Location: </b></label><br>
+    <input type="text" name="planetXeon" id="planetXeon" style="margin-left: 1.5%; width: 35%;" value="5,1"><br>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <label for=fixplanet><b>Planet Ryzen Location: </b></label><br>
+    <input type="text" name="planetRyzen" id="planetRyzen" style="margin-left: 1.5%; width: 35%;" value="6,5"><br><br>
 
 
+     <!-- SPACE STATIONS -->
+    <label for=station><b>How many Space Stations would you like: </b></label><br>
+    <select name="station" id="StationNum"><br> <option> 0 <option> 1 <option> 2 <option> 3 </select><br><br>
+   
+    <label for="planets"><b>Space Station Locations: </b></label><br>
+        <input type="radio" name="StationType" id="RandomStation" checked> Random <br>
+        <input type="radio" name="StationType" id="FixedStation"> Fixed <br><br>
+
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <label for=fixstation><b>Space Stations Locations: </b></label><br>
+    <p style="margin-left: 1.5%;"> Parse each individual station with a ( # ) and the coordinates with a ( , ) as shown.</p>
+    
+    <input type="text" name="SpaceStationLocations" id="SpaceStationLocations" style="margin-left: 1.5%; width: 35%;" value="5,4 # 15,10 # 20,6"><br><br>
+
+
+    <!-- Freighters -->
+    <label for=Freighters><b>How many Abandoned Freighters would you like: </b></label><br>
+    <select name="Freighters" id="FreighterNum"><br> <option> 0 <option> 1 <option> 2 <option> 3 </select><br><br>
+
+    <label for="Freighters"><b>Abandoned Freighters Locations: </b></label><br>
+        <input type="radio" name="FreighterType" id="RandomFreighter" checked> Random <br>
+        <input type="radio" name="FreighterType" id="FixedFreighter"> Fixed <br><br>
+
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <label for=fixFreighter><b>Abandoned Freighters Locations: </b></label><br>
+    <p style="margin-left: 1.5%;"> Parse each individual with a ( # ) and the coordinates with a ( , ) as shown.</p>
+    
+    <input type="text" name="FreighterLocations" id="FreighterLocations" style="margin-left: 1.5%; width: 35%;" value="8,2 # 11,12 # 18,3"><br><br>
+
+
+    <!-- Meteor Storms -->
+    <label for=MeteorStorms><b>How many Meteor Storms would you like: </b></label><br>
+    <select name="MeteorStorms" id="MeteorNum"><br> <option> 0 <option> 1 <option> 2 <option> 3 </select><br><br>
+    
+    <label for="MeteorStorms"><b>Meteor Storms Locations: </b></label><br>
+        <input type="radio" name="MeteorType" id="RandomMeteor" checked> Random <br>
+        <input type="radio" name="MeteorType" id="FixedMeteor"> Fixed <br><br>
+
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <label for=fixMeteor><b>Meteor Storms Locations: </b></label><br>
+    <p style="margin-left: 1.5%;"> Parse each individual with a ( # ) and the coordinates with a ( , ) as shown.</p>
+    
+    <input type="text" name="MeteorLocations" id="MeteorLocations" style="margin-left: 1.5%; width: 35%;" value="3,6 # 14,11 # 16,7"><br><br>
+
+
+    <!-- Asteroids -->
+    <label for=Asteroids><b>How many Asteroids would you like: </b></label><br>
+    <select name="Asteroids" id="AsteroidsNum"><br> <option> 0 <option> 1 <option> 2 <option> 3 </select><br><br>
+    
+    <label for="Asteroids"><b>Asteroids Locations: </b></label><br>
+        <input type="radio" name="AsteroidsType" id="RandomAsteroids" checked> Random <br>
+        <input type="radio" name="AsteroidsType" id="FixedAsteroids"> Fixed <br><br>
+
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <label for=fixAsteroids><b>Asteroids Locations: </b></label><br>
+    <p style="margin-left: 1.5%;"> Parse each individual with a ( # ) and the coordinates with a ( , ) as shown.</p>
+    
+    <input type="text" name="AsteroidsLocations" id="AsteroidsLocations" style="margin-left: 1.5%; width: 35%;" value="9,8 # 19,13 # 14,8"><br>
+
+
+    <!-- SUBMIT BUTTON -->
     <br><br>
     <a type="submit" id="devSubmitBtn" href="SpaceHunt.html" target="_self" onclick="setStateData();">Submit Data</a> 
 

--- a/gameObjects.js
+++ b/gameObjects.js
@@ -1,32 +1,31 @@
 //Example on how we could have shared definitions of our objects
 //This is obviously incomplete, but an idea that may help us get started
+var devConfig = false;
+var Rand;
 
 if('Config' in localStorage)
 {
+  devConfig = true;
+
   var Config = localStorage.getItem('Config');
-  localStorage.removeItem('Config');
-
+  //localStorage.removeItem('Config');
   Config = Config.split('#');
-  var PlayStyle = Config[10];
 
+  var PlayStyle = Config[10];
   localStorage.setItem('PlayType', PlayStyle);  //save play style choice for supply and energy checks
 
-  for(var i = 0; i < Config.length; i++)
-  {
-    Config[i] = parseInt(Config[i], 10);
-  }
-  //window.alert(Config.join("\n"));
-
-  if(Config[7] == 1) {
-    var Rand = true;
-  }else {
-    var Rand = false;
+  for(var i = 0; i < Config.length; i++) {
+    Config[i] = parseFloat(Config[i]);
   }
 
-  var devConfig = true;
-}
+  //wormhole behavoir
+  Rand = (Config[7] == 1) ? true : false; //determine if wormhole is set to random or fixed
 
-//values wont update with dev config until at least one move have been made
+ } 
+ else {
+ 	devConfig = false;
+ }
+
 
 var spaceship = {
 
@@ -44,10 +43,10 @@ var spaceship = {
   maxCoordY : devConfig ? Config[1] : 127,
 
 
-
   move : function(direction) {
-    directionCheck(direction);
 
+    var collision = directionCheck(direction);
+    WinningRecipeCheck();
     supplyDecrease();
 
     wormholeCheck();
@@ -55,7 +54,7 @@ var spaceship = {
     var retCheck = checkEvents(this.location[0], this.location[1]);
 
     if(this.damaged === true && retCheck !== 3){
-      alert("Your ship is damaged. Energy consumed at 5 times. Repair ASAP.");
+      //alert("Your ship is damaged. Energy consumed at 5 times. Repair ASAP.");
       this.energy = this.energy - this.energyPerDistance * intDistance * 5;
     }
     else{
@@ -72,6 +71,10 @@ var spaceship = {
       this.supplies += Math.floor(this.supplies * 0.02);
     }
 
+    if(collision) {
+      AsteroidCollision();
+    }
+
     setData();
 
     this.displayCurrentCP();
@@ -84,34 +87,98 @@ var spaceship = {
   }
 };
 
-
 function directionCheck(direction) {
 
   intDistance = parseInt(document.getElementById("distance").value);
+  var collision;
 
   switch (direction)
   {
     case "right":
+    collision = checkCollision(intDistance, direction);
     spaceship.location[0] += intDistance;
     break;
 
     case "up":
+    collision = checkCollision(intDistance, direction);
     spaceship.location[1] += intDistance;
     break;
 
     case "left":
+    collision = checkCollision(intDistance, direction);
     spaceship.location[0] -= intDistance;
     break;
 
     case "down":
-    spaceship.location[1] -= intDistance;
+    collision = checkCollision(intDistance, direction);
+    spaceship.location[1] -= intDistance; 
     break;
 
     default:
     console.log("Invalid direction.");
     break;
   }
+
+  return collision;
 }
+
+//simple win function 
+function WinningRecipeCheck() {
+	
+	if(Config != null) {
+		if(spaceship.location[0] == Config[11] && spaceship.location[1] == Config[12]) {
+			window.alert("YOU FOUND THE SECRET KOCA-KOLA RECIPE!!! YOU WIN!!!");
+			window.location.reload();
+		}
+	}
+	if(Config == null && spaceship.location[0] == 25 && spaceship.location[1] == 25) {
+		window.alert("YOU FOUND THE SECRET KOCA-KOLA RECIPE!!! YOU WIN!!!");
+		window.location.reload();
+	}
+}
+
+function checkCollision(intDistance, direction) {
+
+  var xCoor = spaceship.location[0]; 
+  var yCoor = spaceship.location[1];
+
+  for(var i = 0; i < intDistance; i++) {
+    if(direction == "right") {
+      xCoor += 1;
+    } else if (direction == "up") {
+      yCoor += 1;
+    } else if (direction == "left") {
+      xCoor -= 1;
+    } else if (direction == "down") {
+      yCoor -= 1;
+    }
+
+    if(Config != null) {
+    	if(xCoor == Config[37] && yCoor == Config[38] || xCoor == Config[39] && yCoor == Config[40] || xCoor == Config[41] && yCoor == Config[42]) {
+    		return true;
+    	}
+    }
+    if(Config == null && (xCoor == 6 && yCoor == 5 || xCoor == 0 && yCoor == 1 || xCoor == 3 && yCoor == 2) ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
+function AsteroidCollision() {
+	var chance = Math.random() * 100;
+	
+	if (chance < 90) { // 0-90% chance to be damaged and not die
+    	window.alert("You collided with a ASTEROID!!! Luckily you survied with just some damages to your ship, tread carfully from here on! Due to the damage the ship now consumes energy at 5 times the usual rate.");
+      spaceship.damaged = true;
+  } else {
+  		window.alert("You collided with a ASTEROID!!! The ship has exploded and your crew have all perished!");
+  		window.location.reload();
+	}
+}
+
 
 function wormholeCheck() {
 //Wormhole check
@@ -165,13 +232,20 @@ var celestialMap = {
   toString : function() {}
 };
 
+
 //Map could contain 128x128 celestialPoint() objects
 var gameSpace = [];
 window.onload = function() {
+	var i = 0, j = 0;
+	var devConfig;
+	
+	if('Config' in localStorage) { devConfig = true; } else { devConfig = false;}
+	localStorage.removeItem('Config');
+
   // Initialize gameSpace
-  for (var i = 0; i <= spaceship.maxCoordX; i++) {
+  for (i = 0; i <= spaceship.maxCoordX; i++) {
     var CPRow = [];
-    for (var j = 0; j <= spaceship.maxCoordY; j++) {
+    for (j = 0; j <= spaceship.maxCoordY; j++) {
       CPRow.push(new celestialPoint([i, j]));
     }
     gameSpace.push(CPRow);
@@ -180,46 +254,43 @@ window.onload = function() {
   // Display starting CP
   spaceship.displayCurrentCP();
 
-  // Set locations of the 3 planets
-  // For now the locations are hardcoded
-  gameSpace[2][0].celestialObjects.push("Planet Celeron");
-  gameSpace[5][1].celestialObjects.push("Planet Xeon");
-  gameSpace[6][5].celestialObjects.push("Planet Ryzen");
+  //Default Map items
+  Default = [25, 25, 2, 0, 5, 1, 6, 5, 30, 48, 83, 14, 19, 65, 24, 39, 62, 11, 33, 2, 6, 12, 24, 35, 78, 26, 90, 5, 0, 1, 3, 2, 5, 20, 14, 8, 32, 0, 2, 25, 0, 30 ,71, 25, 55, 76, 102, 82, 1, 1];
+  MapItemNames = ["Winning Recipe", "Planet Celeron", "Planet Xeon", "Planet Ryzen", "Space Station", "Space Station", "Space Station", "Freighter", "Freighter", "Freighter", "Meteor Storm", "Meteor Storm","Meteor Storm", "Asteroid", "Asteroid", "Asteroid", "Venus", "Mars", "Jupiter", "Mercury", "Sun", "Saturn", "Uranus", "Neptune", "Moon"];
 
-  // Add the 3 planets to CM
-  celestialMap.celestialPoints.add(gameSpace[2][0]);
-  celestialMap.celestialPoints.add(gameSpace[5][1]);
-  celestialMap.celestialPoints.add(gameSpace[6][5]);
+  //Map population
+  j = 0;
+  if(devConfig) {	//dev Config items
 
-  // Set locations of the 4 freighters
-  // For now the locations are hardcoded
-  gameSpace[24][39].celestialObjects.push("freighter");
-  gameSpace[62][11].celestialObjects.push("freighter");
-  gameSpace[33][2].celestialObjects.push("freighter");
-  gameSpace[5][9].celestialObjects.push("freighter");
+  	for(i = 11; i < Config.length; i += 2) {     
+      if(Config[i] != 0.5 && Config[i+1] != 0.5) {
+        gameSpace[Config[i]][Config[i+1]].celestialObjects.push(MapItemNames[j]);	
+  		} 
+  		//console.log("ConfigX: ", Config[i], " ConfigY: ", Config[i+1], "Name: ", MapItemNames[j] );
+  		j += 1;	
+  	}
+  	
+  	j = 16;
+  	for(i = 32; i < Default.length; i += 2) {
+  		gameSpace[Default[i]][Default[i+1]].celestialObjects.push(MapItemNames[j]);	
+  		//console.log("DefaultX: ", Default[i], " DefaultY: ", Default[i+1], "Name: ", MapItemNames[j] );
+  		j += 1;	
+  	}
+  } else {		//default Config items
 
-  // Set locations of the 3 Meteor Storms
-  // For now the locations are hardcoded
-  gameSpace[6][12].celestialObjects.push("Meteor Storm");
-  gameSpace[24][35].celestialObjects.push("Meteor Storm");
-  gameSpace[78][26].celestialObjects.push("Meteor Storm");
-
-  // Set locations of planets
-  // For now the locations are hardcoded
-  gameSpace[5][20].celestialObjects.push("Venus");
-  gameSpace[14][8].celestialObjects.push("Mars");
-  gameSpace[32][0].celestialObjects.push("Jupiter");
-  gameSpace[2][25].celestialObjects.push("Mercury");
-  gameSpace[0][30].celestialObjects.push("Sun");
-  gameSpace[71][25].celestialObjects.push("Saturn");
-  gameSpace[55][76].celestialObjects.push("Uranus");
-  gameSpace[102][82].celestialObjects.push("Neptune");
-  gameSpace[1][1].celestialObjects.push("Moon");
-
-  // For debugging purposses, here are some celestial objects
-  gameSpace[6][5].celestialObjects.push("asteroid");
-  gameSpace[0][1].celestialObjects.push("asteroid");
-  gameSpace[3][2].celestialObjects.push("asteroid");
+  	for(i = 0; i < Default.length; i += 2) {
+  		gameSpace[Default[i]][Default[i+1]].celestialObjects.push(MapItemNames[j]);	
+  		//console.log("DefaultX: ", Default[i], " DefaultY: ", Default[i+1], "Name: ", MapItemNames[j] );
+  		j += 1;
+  	}
+  }
+  
+  	
+	// Add the 3 planets to CM
+	celestialMap.celestialPoints.add(gameSpace[devConfig ? Config[13] : 2][devConfig ? Config[14] : 0]);
+	celestialMap.celestialPoints.add(gameSpace[devConfig ? Config[15] : 5][devConfig ? Config[16] : 1]);
+	celestialMap.celestialPoints.add(gameSpace[devConfig ? Config[17] : 6][devConfig ? Config[18] : 5]);
+  
 
   // Display starting CM with the 3 planets on it
   celestialMap.display();

--- a/gameObjects.js
+++ b/gameObjects.js
@@ -21,8 +21,7 @@ if('Config' in localStorage)
   //wormhole behavoir
   Rand = (Config[7] == 1) ? true : false; //determine if wormhole is set to random or fixed
 
- } 
- else {
+ } else {
  	devConfig = false;
  }
 
@@ -45,7 +44,10 @@ var spaceship = {
 
   move : function(direction) {
 
-    var collision = directionCheck(direction);
+    intDistance = parseInt(document.getElementById("distance").value);
+    var collision = checkCollision(intDistance, direction);
+    
+    directionCheck(direction, intDistance);
     WinningRecipeCheck();
     supplyDecrease();
 
@@ -53,13 +55,8 @@ var spaceship = {
 
     var retCheck = checkEvents(this.location[0], this.location[1]);
 
-    if(this.damaged === true && retCheck !== 3){
-      //alert("Your ship is damaged. Energy consumed at 5 times. Repair ASAP.");
-      this.energy = this.energy - this.energyPerDistance * intDistance * 5;
-    }
-    else{
-      this.energy = this.energy - this.energyPerDistance * intDistance;
-    }
+    energyDecrease(retCheck, collision, intDistance);
+    
     if(checkEnergyAndSupplies(this.energy, this.supplies) == true)
       return;
 
@@ -87,30 +84,23 @@ var spaceship = {
   }
 };
 
-function directionCheck(direction) {
-
-  intDistance = parseInt(document.getElementById("distance").value);
-  var collision;
+function directionCheck(direction, intDistance) {
 
   switch (direction)
   {
     case "right":
-    collision = checkCollision(intDistance, direction);
     spaceship.location[0] += intDistance;
     break;
 
     case "up":
-    collision = checkCollision(intDistance, direction);
     spaceship.location[1] += intDistance;
     break;
 
     case "left":
-    collision = checkCollision(intDistance, direction);
     spaceship.location[0] -= intDistance;
     break;
 
     case "down":
-    collision = checkCollision(intDistance, direction);
     spaceship.location[1] -= intDistance; 
     break;
 
@@ -118,10 +108,28 @@ function directionCheck(direction) {
     console.log("Invalid direction.");
     break;
   }
-
-  return collision;
 }
 
+function energyDecrease(retCheck, collision, intDistance) {
+
+  if(collision === 0 || spaceship.damaged === true) {   //ship has not collided with anything
+    
+    if(spaceship.damaged === true && retCheck !== 3){
+      spaceship.energy = spaceship.energy - spaceship.energyPerDistance * intDistance * 5;
+    
+    } else {
+      spaceship.energy = spaceship.energy - spaceship.energyPerDistance * intDistance;
+    }
+  
+  } else {  //ship has collided with something
+    var damagedDistance = intDistance - collision; //cp's to deplete a damaged ship energy, collision is the marker of the asteroid so that will be the undamage value
+    
+    //undamaged
+    spaceship.energy = spaceship.energy - spaceship.energyPerDistance * collision; //collision is the amount of cp's where the ship is undamaged    
+    //damaged
+    spaceship.energy = spaceship.energy - spaceship.energyPerDistance * damagedDistance * 5;
+  }
+}
 //simple win function 
 function WinningRecipeCheck() {
 	
@@ -131,6 +139,7 @@ function WinningRecipeCheck() {
 			window.location.reload();
 		}
 	}
+
 	if(Config == null && spaceship.location[0] == 25 && spaceship.location[1] == 25) {
 		window.alert("YOU FOUND THE SECRET KOCA-KOLA RECIPE!!! YOU WIN!!!");
 		window.location.reload();
@@ -155,15 +164,15 @@ function checkCollision(intDistance, direction) {
 
     if(Config != null) {
     	if(xCoor == Config[37] && yCoor == Config[38] || xCoor == Config[39] && yCoor == Config[40] || xCoor == Config[41] && yCoor == Config[42]) {
-    		return true;
+        return i+1;
     	}
     }
     if(Config == null && (xCoor == 6 && yCoor == 5 || xCoor == 0 && yCoor == 1 || xCoor == 3 && yCoor == 2) ) {
-      return true;
+      return i+1;
     }
   }
 
-  return false;
+  return 0;
 }
 
 
@@ -190,8 +199,8 @@ function wormholeCheck() {
     {
       spaceship.location[0] = Math.floor((Math.random() * spaceship.maxCoordX) + 1);
       spaceship.location[1] = Math.floor((Math.random() * spaceship.maxCoordY) + 1);
-    }
-    else
+    
+    } else
     {
       spaceship.location[0] = Config[8];
       spaceship.location[1] = Config[9];
@@ -259,9 +268,9 @@ window.onload = function() {
   MapItemNames = ["Winning Recipe", "Planet Celeron", "Planet Xeon", "Planet Ryzen", "Space Station", "Space Station", "Space Station", "Freighter", "Freighter", "Freighter", "Meteor Storm", "Meteor Storm","Meteor Storm", "Asteroid", "Asteroid", "Asteroid", "Venus", "Mars", "Jupiter", "Mercury", "Sun", "Saturn", "Uranus", "Neptune", "Moon"];
 
   //Map population
-  j = 0;
-  if(devConfig) {	//dev Config items
 
+  if(devConfig) {	//dev Config items
+    j = 0;
   	for(i = 11; i < Config.length; i += 2) {     
       if(Config[i] != 0.5 && Config[i+1] != 0.5) {
         gameSpace[Config[i]][Config[i+1]].celestialObjects.push(MapItemNames[j]);	
@@ -276,8 +285,9 @@ window.onload = function() {
   		//console.log("DefaultX: ", Default[i], " DefaultY: ", Default[i+1], "Name: ", MapItemNames[j] );
   		j += 1;	
   	}
+  
   } else {		//default Config items
-
+    j = 0;
   	for(i = 0; i < Default.length; i += 2) {
   		gameSpace[Default[i]][Default[i+1]].celestialObjects.push(MapItemNames[j]);	
   		//console.log("DefaultX: ", Default[i], " DefaultY: ", Default[i+1], "Name: ", MapItemNames[j] );


### PR DESCRIPTION
A bug was occurring where if you opened the devMenu on start and only changed the starting location all non-selected items would be loaded to point 0,0 causing a immediate meteor collision even if you didn't move any distance.

The issue was when pulling the data out of localstroage and converting strings to ints I was using parseInt instead of parseFloat thus setting all the 0.5 values that were used to mark the items not to populate on the map to 0's instead of 0.5. Bypassing the if conditional to not populate them on the map. This in turn placed all those items at point 0,0. 

The fix was simply to change the parseInt to parseFloat to keep the 0.5 and be blocked by the if conditional on the map population function.